### PR TITLE
Update README to indicate that hideFunctions is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ treeify.asLines(obj, showValues (boolean), [hideFunctions (boolean),] lineCallba
 ```
 ### asTree()
 ```js
-treeify.asTree(obj, showValues (boolean), hideFunctions (boolean)): String
+treeify.asTree(obj, showValues (boolean), [hideFunctions (boolean)]): String
 ```
 
 Running the tests


### PR DESCRIPTION
The README example
```js
var treeify = require('treeify');
console.log(
   treeify.asTree({
      apples: 'gala',      //  ├─ apples: gala
      oranges: 'mandarin'  //  └─ oranges: mandarin
   }, true)
);
```
uses `asTree` without passing a `hideFunctions` option. This PR updates the API documentation to indicate that `hideFunctions` is optional both in `asLines` and `asTree`